### PR TITLE
Increase compileSdk Version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
     
     if (project.android.hasProperty("namespace")) {
         namespace 'com.hemanthraj.fluttercompass'


### PR DESCRIPTION
We have a problem when we want to build apk 
```
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':flutter_compass:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR:/__w/***ate/***ate/build/flutter_compass/intermediates/merged_res/release/values/values.xml:194: AAPT: error: resource android:attr/lStar not found.
```

So we need to bump version of the compilerSdk to 34 to resolve 